### PR TITLE
Fix vertex data type error

### DIFF
--- a/assets/maujoe.simple_wind_shader_2d/shaders/wind_2d.shader
+++ b/assets/maujoe.simple_wind_shader_2d/shaders/wind_2d.shader
@@ -22,5 +22,5 @@ float getWind(vec2 vertex, vec2 uv, float timer){
 	}
 
 void vertex() {
-	VERTEX.x += getWind(VERTEX, UV, TIME);
+	VERTEX.x += getWind(VERTEX.xy, UV, TIME);
 }


### PR DESCRIPTION
Hi @Maujoe!

We've used your shader with Godot 3.0.6. We had to make a small adjustment for it to work with a 2D-Sprite: It looks like even though the sprite is a 2D object, the vertex has a z-coordinate, which causes the code to fail.